### PR TITLE
Replace from.std with bare import statements

### DIFF
--- a/source/bolts/range.d
+++ b/source/bolts/range.d
@@ -4,6 +4,8 @@
 module bolts.range;
 
 import bolts.internal;
+import std.range : isInputRange;
+import std.meta : allSatisfy;
 
 /**
     True if R is a `SortedRange`
@@ -37,7 +39,7 @@ unittest {
         Args[1] = the sorting predicate to fallback to if `Range` is not a `SortedRange`
 */
 template sortingPredicate(Args...)
-if ((Args.length == 1 || Args.length == 2) && from.std.range.isInputRange!(from.bolts.meta.TypesOf!Args[0])) {
+if ((Args.length == 1 || Args.length == 2) && isInputRange!(from.bolts.meta.TypesOf!Args[0])) {
     import bolts.meta: TypesOf;
     import std.range: SortedRange;
     import std.functional: binaryFun;
@@ -71,7 +73,7 @@ unittest {
 }
 
 /// Finds the CommonType of a list of ranges
-template CommonTypeOfRanges(Rs...) if (from.std.meta.allSatisfy!(from.std.range.isInputRange, Rs)) {
+template CommonTypeOfRanges(Rs...) if (allSatisfy!(isInputRange, Rs)) {
     import std.traits: CommonType;
     import std.meta: staticMap;
     import std.range: ElementType;

--- a/source/bolts/traits.d
+++ b/source/bolts/traits.d
@@ -4,6 +4,8 @@
 module bolts.traits;
 
 import bolts.internal;
+import std.traits : TemplateOf;
+import std.traits : hasMember;
 
 ///
 unittest {
@@ -667,7 +669,7 @@ template StringOf(alias U, string sep = ", ", string beg = "!(", string end = ")
 }
 
 /// Ditto
-string StringOf(T, string sep = ", ", string beg = "!(", string end = ")")() if (is(from.std.traits.TemplateOf!T == void)) {
+string StringOf(T, string sep = ", ", string beg = "!(", string end = ")")() if (is(TemplateOf!T == void)) {
     return T.stringof;
 }
 
@@ -779,7 +781,7 @@ template isCopyConstructable(T...) if (T.length == 1) {
     alias U = from.bolts.meta.TypesOf!T[0];
     enum isCopyConstructable
         = __traits(compiles, { auto r = U.init; U copy = r; })
-        && !from.std.hasMember!(U, "__xpostblit");
+        && !hasMember!(U, "__xpostblit");
 }
 
 ///
@@ -803,7 +805,7 @@ template isNonTriviallyCopyConstructable(T...) if (T.length == 1) {
     alias U = from.bolts.meta.TypesOf!T[0];
     enum isNonTriviallyCopyConstructable
         = isCopyConstructable!U
-        && from.std.traits.hasMember!(U, "__ctor");
+        && hasMember!(U, "__ctor");
 }
 
 ///
@@ -825,7 +827,7 @@ template isTriviallyCopyConstructable(T...) if (T.length == 1) {
     alias U = from.bolts.meta.TypesOf!T[0];
     enum isTriviallyCopyConstructable
         = isCopyConstructable!U
-        && !from.std.traits.hasMember!(U, "__ctor");
+        && !hasMember!(U, "__ctor");
 }
 
 ///


### PR DESCRIPTION
`from.std` pulls in the complete standard library. This is an issue
for projects targeting webassembly because the standard library is
not compatible with it.

After merging this could you be so kind to make a (beta) release in the next few days, as well as to bump the optional package? Much appreciated.