### PR TITLE
Refraction compact mixture

### DIFF
--- a/source/bolts/experimental/refraction.d
+++ b/source/bolts/experimental/refraction.d
@@ -7,7 +7,7 @@ This module helps building functions from other functions.
  parameter storage classes and user-defined attributes, this requires building
  a string mixin. In addition, the mixed-in code must refer only to local names,
  if it is to work across module boundaires. This problem and its solution are
- by Adam D. Ruppe in a Tip of the Week, available here:
+described  by Adam D. Ruppe in a Tip of the Week, available here:
  https://stackoverflow.com/questions/32615733/struct-composition-with-mixin-and-templates/32621854#32621854
 
  This module facilitates the  creation of such mixins.


### PR DESCRIPTION
This makes the mixtures more compact:
*  when the parameter list is not edited: `Parameters!fun _0` for the parameter list. This is used when the parameter list is not edited.
* when the parameter list has been edited but previous parameters are re-used without alterations to their storage classes or UDAS: `Parameters!fun[i..i+1]` for the i-th argument.
