### PR TITLE
Fix build errors when using GDC

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -19,7 +19,10 @@
 				"-mixin=mixins.txt"
 			],
 			"name": "unittest",
-			"targetType": "library"
+			"targetType": "library",
+			"excludedSourceFiles-gdc": [
+				"source/bolts/experimental/refraction.d"
+			]
 		}
 	],
 }

--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,10 @@
     },
 	"configurations": [
 		{
-			"dflags": [
+			"dflags-dmd": [
+				"-mixin=mixins.txt"
+			],
+			"dflags-ldc": [
 				"-mixin=mixins.txt"
 			],
 			"name": "unittest",

--- a/source/bolts/from.d
+++ b/source/bolts/from.d
@@ -31,20 +31,20 @@ unittest {
 }
 
 private template CanImport(string moduleName) {
-    enum CanImport = __traits(compiles, { mixin("import ", moduleName, ";"); });
+    enum CanImport = __traits(compiles, { mixin("import " ~ moduleName ~ ";"); });
 }
 
 private template ModuleContainsSymbol(string moduleName, string symbolName) {
     enum ModuleContainsSymbol = CanImport!moduleName && __traits(compiles, {
-        mixin("import ", moduleName, ":", symbolName, ";");
+        mixin("import " ~ moduleName ~ ":" ~ symbolName ~ ";");
     });
 }
 
 private struct FromImpl(string moduleName) {
     template opDispatch(string symbolName) {
         static if (ModuleContainsSymbol!(moduleName, symbolName)) {
-            mixin("import ", moduleName,";");
-            mixin("alias opDispatch = ", symbolName, ";");
+            mixin("import " ~ moduleName ~ ";");
+            mixin("alias opDispatch = " ~ symbolName ~ ";");
         } else {
             static if (moduleName.length == 0) {
                 enum opDispatch = FromImpl!(symbolName)();


### PR DESCRIPTION
Currently this project does not compile when using the GNU D Compiler.

This pull request:
 - Removes unsupported compile flags when using GDC.
 - Disables one of the experimental source files as it produces syntax errors when using GDC.
 - Changes the syntax of certain mixins to be compatible with GDC.

Builds and unit tests now succeed for DMD, LDC, and GDC.